### PR TITLE
Select used edge package from install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ You will be prompted for selecting edge backend based on installed packages that
    * `-p` or `--production`: to be used when packaging with (i.e.) electron-builder. It will skip prompting for edge backend and will take correctly the dll path needed for windows.<br>
       **Note** that `-p` flag require that edge backend has been specified during installation.
 
+   * `-nnp:<package-name>`: specify the edge package to use. Skips the selection process on install if a valid package is specified.
+
+
 ## Usage
 First of all you need to require the module inside your app this way:
 ```javascript

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ You will be prompted for selecting edge backend based on installed packages that
 
    * `-nnp:<package-name>`: specify the edge package to use. Skips the selection process on install if a valid package is specified.
 
-
 ## Usage
 First of all you need to require the module inside your app this way:
 ```javascript

--- a/install/install_win.js
+++ b/install/install_win.js
@@ -21,6 +21,17 @@ module.exports = function(){
 		}
 	}
 
+	let packageSelection;
+	var nnpFilter = new RegExp('^-nnp:.*$', 'g');
+	let nnpFlag = flags.filter(function(value) {
+		return nnpFilter.test(value);
+	});
+
+	if (nnpFlag.length > 0) {
+		packageSelection = nnpFlag[0].split(':')[1];
+	}
+
+
 	var pattern = new RegExp(".*edge.*", "gi");
 	var choices;
 
@@ -32,6 +43,13 @@ module.exports = function(){
 		choices = choices.filter(value => {
 			return pattern.test(value);
 		});
+
+		if (packageSelection) {
+			let index =  choices.indexOf(packageSelection);
+			if (index >= 0) {
+				return makeEnv(choices[index]);
+			}
+		}
 
 		choices.push('Not listed');
 


### PR DESCRIPTION
Adds flag `-nnp:<package-name>` to specify the used edge package from the install command. 

i.e. `npm install -nnp:electron-edge-js` 

Helpful for CI builds etc. 